### PR TITLE
fix: docker service update with `--detach=false` hangs on services wi…

### DIFF
--- a/shepherd
+++ b/shepherd
@@ -97,7 +97,7 @@ update_services() {
     else
       logger "Trying to update service $name with image $image" "true"
 
-      num_tasks=$(docker service ls | grep "$name" | awk '{print $4}')
+      num_tasks=$(docker service ls -f "name=$name" | awk 'NR==2{print $4}')
       if [[ $num_tasks = 0/* ]]; then
         detach_option="--detach=true"
       fi

--- a/shepherd
+++ b/shepherd
@@ -97,6 +97,11 @@ update_services() {
     else
       logger "Trying to update service $name with image $image" "true"
 
+      tasks_num=`docker service ls | grep "$name" | awk '{print $4}'`
+      if [[ $tasks_num = 0/* ]]; then
+        detach_option="--detach=true"
+      fi
+
       # shellcheck disable=SC2086
       if ! timeout "${TIMEOUT:-300}" docker "${config_flag[@]}" service update "$name" $detach_option $registry_auth $no_resolve_image_flag ${UPDATE_OPTIONS} --image="$image" > /dev/null; then
         logger "Service $name update failed on $hostname!"

--- a/shepherd
+++ b/shepherd
@@ -97,8 +97,8 @@ update_services() {
     else
       logger "Trying to update service $name with image $image" "true"
 
-      tasks_num=$(docker service ls | grep "$name" | awk '{print $4}')
-      if [[ $tasks_num = 0/* ]]; then
+      num_tasks=$(docker service ls | grep "$name" | awk '{print $4}')
+      if [[ $num_tasks = 0/* ]]; then
         detach_option="--detach=true"
       fi
 

--- a/shepherd
+++ b/shepherd
@@ -97,7 +97,7 @@ update_services() {
     else
       logger "Trying to update service $name with image $image" "true"
 
-      tasks_num=`docker service ls | grep "$name" | awk '{print $4}'`
+      tasks_num=$(docker service ls | grep "$name" | awk '{print $4}')
       if [[ $tasks_num = 0/* ]]; then
         detach_option="--detach=true"
       fi


### PR DESCRIPTION
When a service has 0 tasks, the `docker service update` command with the `--detach=false` parameter hangs.

Read more here: https://github.com/docker/cli/issues/627