### PR TITLE
Switch to official docker image v24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mazzolino/docker:20
+FROM docker:24
 
 ENV SLEEP_TIME='5m'
 ENV FILTER_SERVICES=''


### PR DESCRIPTION
Unfortunately, this means losing armhf support for now. (I currently don't have the time to maintain the custom docker-in-docker armhf image anymore.)

fixes #105