### PR TITLE
Fix: other flags may not be combined with `--rollback`

### DIFF
--- a/shepherd
+++ b/shepherd
@@ -113,7 +113,7 @@ update_services() {
         if [[ "${ROLLBACK_ON_FAILURE+x}" ]]; then
           logger "Rolling $name back"
           # shellcheck disable=SC2086
-          docker "${config_flag[@]}" service update "$name" $detach_option $registry_auth $no_resolve_image_flag ${ROLLBACK_OPTIONS} --rollback > /dev/null
+          docker "${config_flag[@]}" service update "$name" $detach_option ${ROLLBACK_OPTIONS} --rollback > /dev/null
         fi
         if [[ "$apprise_sidecar_url" != "" ]]; then
           title="[Shepherd] Service $name update failed on $hostname"


### PR DESCRIPTION
As stated [here](https://docs.docker.com/engine/swarm/services/#:~:text=Note%20that,.), you should not pass other flags with the `--rollback` flag. Otherwise, you will get this error message:

```
other flags may not be combined with --rollback
```

And this error causes the shepherd container to exist with a non-zero exit code:

```
ID             NAME             IMAGE                       NODE   DESIRED STATE   CURRENT STATE            ERROR                       PORTS
mt76rdcbfaaz   shepherd.1       mazzolino/shepherd:latest   main   Running         Running 13 minutes ago
j1hi6zqylbdn    \_ shepherd.1   mazzolino/shepherd:latest   main   Shutdown        Failed 13 minutes ago    "task: non-zero exit (1)"
xyj7e0r52vog    \_ shepherd.1   mazzolino/shepherd:latest   main   Shutdown        Failed 3 hours ago       "task: non-zero exit (1)"
vd0nvzo9kd2y    \_ shepherd.1   mazzolino/shepherd:latest   main   Shutdown        Failed 4 hours ago       "task: non-zero exit (1)"
53azr021ok4i    \_ shepherd.1   mazzolino/shepherd:latest   main   Shutdown        Failed 4 hours ago       "task: non-zero exit (1)"
```

For this reason, I removed the `--no-resolve-image` and `--with-registry-auth` flags from the rollback command.