### PR TITLE
Improve notifications handling

### DIFF
--- a/shepherd
+++ b/shepherd
@@ -47,6 +47,17 @@ authenticate_to_registries() {
   fi
 }
 
+send_notification() {
+  if [[ "$apprise_sidecar_url" != "" ]]; then
+    status=$(curl -s -X POST -H "Content-Type: application/json" --data "{\"title\": \"$1\", \"body\": \"$2\", \"notify_type\": \"$3\"}" "$apprise_sidecar_url")
+    if [[ $status = 0 ]]; then
+      logger "Sent notification"
+    else
+      logger "Failed sending notification!"
+    fi
+  fi
+}
+
 update_services() {
   local ignorelist="$1"
   local supports_detach_option=$2
@@ -94,11 +105,11 @@ update_services() {
 
     if ! DOCKER_CLI_EXPERIMENTAL=enabled docker "${config_flag[@]}" manifest inspect $insecure_registry_flag "$image" > /dev/null; then
       logger "Error updating service $name! Image $image does not exist or it is not available"
-      if [[ "$apprise_sidecar_url" != "" ]]; then
-        title="[Shepherd] Error updating service $name"
-        body="$(date) Service $name Image $image does not exist or it is not available"
-        curl -X POST -H "Content-Type: application/json" --data "{\"title\": \"$title\", \"body\": \"$body\", \"type\": \"failure\"}" "$apprise_sidecar_url"
-      fi
+
+      title="[Shepherd] Error updating service $name"
+      body="$(date) Service $name Image $image does not exist or it is not available"
+      send_notification $title $body "failure"
+
     else
       logger "Trying to update service $name with image $image" "true"
 
@@ -115,11 +126,11 @@ update_services() {
           # shellcheck disable=SC2086
           docker "${config_flag[@]}" service update "$name" $detach_option ${ROLLBACK_OPTIONS} --rollback > /dev/null
         fi
-        if [[ "$apprise_sidecar_url" != "" ]]; then
-          title="[Shepherd] Service $name update failed on $hostname"
-          body="$(date) Service $name failed to update to $(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
-          curl -X POST -H "Content-Type: application/json" --data "{\"title\": \"$title\", \"body\": \"$body\", \"type\": \"failure\"}" "$apprise_sidecar_url"
-        fi
+
+        title="[Shepherd] Service $name update failed on $hostname"
+        body="$(date) Service $name failed to update to $(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
+        send_notification $title $body "failure"
+
         continue # continue with next service
       fi
 
@@ -130,11 +141,10 @@ update_services() {
         logger "No updates to service $name!" "true"
       else
         logger "Service $name was updated!"
-        if [[ "$apprise_sidecar_url" != "" ]]; then
-          title="[Shepherd] Service $name updated on $hostname"
-          body="$(date) Service $name was updated from $previous_image to $current_image"
-          curl -X POST -H "Content-Type: application/json" --data "{\"title\": \"$title\", \"body\": \"$body\", \"type\": \"success\"}" "$apprise_sidecar_url"
-        fi
+
+        title="[Shepherd] Service $name updated on $hostname"
+        body="$(date) Service $name was updated from $previous_image to $current_image"
+        send_notification $title $body "success"
 
         if [[ "$image_autoclean_limit" != "" ]]; then
           logger "Cleaning up old docker images, leaving last $image_autoclean_limit"

--- a/shepherd
+++ b/shepherd
@@ -49,12 +49,8 @@ authenticate_to_registries() {
 
 send_notification() {
   if [[ "$apprise_sidecar_url" != "" ]]; then
-    status=$(curl -s -X POST -H "Content-Type: application/json" --data "{\"title\": \"$1\", \"body\": \"$2\", \"notify_type\": \"$3\"}" "$apprise_sidecar_url")
-    if [[ $status = 0 ]]; then
-      logger "Sent notification"
-    else
-      logger "Failed sending notification!"
-    fi
+    status=$(curl --no-progress-meter -X POST -H "Content-Type: application/json" --data "{\"title\": \"$1\", \"body\": \"$2\", \"notify_type\": \"$3\"}" "$apprise_sidecar_url")
+    logger "Sending notification: $status"
   fi
 }
 
@@ -108,7 +104,7 @@ update_services() {
 
       title="[Shepherd] Error updating service $name"
       body="$(date) Service $name Image $image does not exist or it is not available"
-      send_notification $title $body "failure"
+      send_notification "$title" "$body" "failure"
 
     else
       logger "Trying to update service $name with image $image" "true"
@@ -129,7 +125,7 @@ update_services() {
 
         title="[Shepherd] Service $name update failed on $hostname"
         body="$(date) Service $name failed to update to $(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}')"
-        send_notification $title $body "failure"
+        send_notification "$title" "$body" "failure"
 
         continue # continue with next service
       fi
@@ -144,7 +140,7 @@ update_services() {
 
         title="[Shepherd] Service $name updated on $hostname"
         body="$(date) Service $name was updated from $previous_image to $current_image"
-        send_notification $title $body "success"
+        send_notification "$title" "$body" "success"
 
         if [[ "$image_autoclean_limit" != "" ]]; then
           logger "Cleaning up old docker images, leaving last $image_autoclean_limit"


### PR DESCRIPTION
Improved a bit the Apprise notification handling:
- made `curl` silent so we don't see the ugly progess bar in the logs anymore
- adapted the notification type parameter (depends on this PR: https://github.com/djmaze/apprise-microservice/pull/8)
- refactored code to extract the notification sending in a separate function to reduce code duplication
- added a log entry to indicate whether the notification was successful or not with the `curl` result